### PR TITLE
Add productFlavor support

### DIFF
--- a/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
@@ -21,7 +21,7 @@ class AndroidJavafmtPlugin implements Plugin<Project> {
     def fmtTasks = []
 
     variants.all { variant ->
-      def name = variant.buildType.name
+      def name = variant.name
       def fmt = project.tasks.create "fmt${name.capitalize()}", JavaFmtTask
       fmt.dependsOn variant.javaCompile
       fmt.source variant.javaCompile.source


### PR DESCRIPTION
Use the entire module variant’s name when creating tasks to avoid conflicts in projects with multiple productFlavors. It's a pretty straightforward and tiny change. (#2)

For an example project with the productFlavors `flavor1` and `flavor2`, this generates the following tasks:

* fmtFlavor1Debug
* fmtFlavor1Release
* fmtFlavor2Debug
* fmtFlavor2Release