### PR TITLE
add verify fmt task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile localGroovy()
   compile 'com.android.tools.build:gradle:1.1.0-rc3'
   compile 'com.google.googlejavaformat:google-java-format:1.3'
+  compile 'com.googlecode.java-diff-utils:diffutils:1.2.1'
   compile 'com.google.guava:guava:19.0'
 }
 

--- a/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
@@ -4,6 +4,7 @@ import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.StopExecutionException
 
 class AndroidJavafmtPlugin implements Plugin<Project> {
@@ -19,21 +20,30 @@ class AndroidJavafmtPlugin implements Plugin<Project> {
     }
 
     def fmtTasks = []
+    def verifyFmtTasks = []
 
     variants.all { variant ->
-      def name = variant.name
-      def fmt = project.tasks.create "fmt${name.capitalize()}", JavaFmtTask
+      def fmt = project.tasks.create "fmt${variant.name.capitalize()}", JavaFmtTask
       fmt.dependsOn variant.javaCompile
       fmt.source variant.javaCompile.source
       fmt.exclude('**/BuildConfig.java')
       fmt.exclude('**/R.java')
       project.tasks.getByName("assemble").dependsOn fmt
       fmtTasks.add fmt
-    }
 
+      def verifyFmt = project.tasks.create "verifyFmt${variant.name.capitalize()}", VerifyFmtTask
+      verifyFmt.dependsOn variant.javaCompile
+      verifyFmt.source variant.javaCompile.source
+      verifyFmt.exclude('**/BuildConfig.java')
+      verifyFmt.exclude('**/R.java')
+      verifyFmtTasks.add verifyFmt
+    }
 
     def fmt = project.tasks.create "fmt"
     fmt.dependsOn fmtTasks
+
+    def verifyFmt = project.tasks.create "verifyFmt"
+    verifyFmt.dependsOn verifyFmtTasks
   }
 
   static def hasPlugin(Project project, Class<? extends Plugin> plugin) {

--- a/src/main/groovy/com/f2prateek/javafmt/JavaFmtTask.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/JavaFmtTask.groovy
@@ -18,9 +18,9 @@ class JavaFmtTask extends SourceTask {
 
     def tasks = getSource().collect { file ->
       return {
-        def input = Files.asCharSource(file, Charsets.UTF_8).read()
-        def output = formatter.formatSource(input)
-        Files.write(output, file, Charsets.UTF_8)
+        def source = Files.asCharSource(file, Charsets.UTF_8).read()
+        def formatted = formatter.formatSource(source)
+        Files.write(formatted, file, Charsets.UTF_8)
         return file
       }
     }

--- a/src/main/groovy/com/f2prateek/javafmt/VerifyFmtTask.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/VerifyFmtTask.groovy
@@ -1,0 +1,79 @@
+package com.f2prateek.javafmt
+
+import com.google.common.base.Charsets
+import com.google.common.io.Files
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.google.googlejavaformat.java.Formatter
+import difflib.DiffUtils
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskExecutionException
+import org.gradle.api.tasks.VerificationTask
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+
+class VerifyFmtTask extends SourceTask implements VerificationTask {
+  @TaskAction
+  def fmt() {
+    def formatter = new Formatter();
+    def executor = Executors.newFixedThreadPool(2,
+            new ThreadFactoryBuilder().setNameFormat("verify-javafmt-pool-%d").build())
+
+    def tasks = getSource().collect { file ->
+      return {
+        def source = Files.asCharSource(file, Charsets.UTF_8).read()
+        def formatted = formatter.formatSource(source)
+
+        if (!source.equals(formatted)) {
+          def patch = DiffUtils.diff(source.readLines(), formatted.readLines());
+          def message = patch.deltas.collect { delta ->
+            def original = delta.getOriginal()
+            def originalLines = original.lines.join("\n")
+            def revised = delta.getRevised()
+            def revisedLines = revised.lines.join("\n")
+            return "\nexpected at line $revised.position:\n$revisedLines\ngot at line $original.position:\n$originalLines\n"
+          }.join('\n')
+          if (getIgnoreFailures()) {
+            logger.warn(message)
+          } else {
+            logger.error(message)
+            throw new VerifyFmtException()
+          }
+        }
+
+        return file
+      }
+    }
+
+    List<Throwable> errors = []
+    def results = executor.invokeAll(tasks)
+    results.each { result ->
+      try {
+        result.get()
+      } catch (ExecutionException e) {
+        if (e.getCause() instanceof VerifyFmtException) {
+          errors.add e.getCause()
+        } else {
+          throw e
+        }
+      }
+    }
+
+    if (!errors.isEmpty()) {
+      throw new TaskExecutionException(this, errors.get(0))
+    }
+  }
+
+  /**
+   * Whether or not this task will ignore failures and continue running the build.
+   */
+  boolean ignoreFailures
+
+  public class VerifyFmtException extends GradleException {
+    public VerifyFmtException() {
+      super("Code style violations found. Run `./gradlew fmt` to format.");
+    }
+  }
+}


### PR DESCRIPTION
Example:

```
expected at line 24:
        new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
            .trackApplicationLifecycleEvents()
got at line 24:
        new Analytics.Builder(this, ANALYTICS_WRITE_KEY).trackApplicationLifecycleEvents()

:analytics-samples:analytics-sample:verifyFmtDebug FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':analytics-samples:analytics-sample:verifyFmtDebug'.
> Code style violations found. Run `./gradlew fmt` to format.
```