### PR TITLE
Fix build file detection.

### DIFF
--- a/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
@@ -9,6 +9,16 @@ import org.gradle.api.tasks.StopExecutionException
 import java.util.regex.Pattern
 
 class AndroidJavafmtPlugin implements Plugin<Project> {
+  // TODO: do via excludes.
+  // Matches:
+  // Windows: \analytics\build\BuildConfig.java
+  // Unix: /analytics/build/BuildConfig.java
+  static BUILD_FILE_PATTERN = Pattern.compile("(.*\\/build\\/.*\\/*.java)|(.*\\build\\.*\\*.java)")
+
+  static boolean isNotBuildFile(String path) {
+    return !BUILD_FILE_PATTERN.matcher(path).matches()
+  }
+
   @Override void apply(Project project) {
     def variants
     if (hasPlugin(project, AppPlugin)) {
@@ -26,22 +36,15 @@ class AndroidJavafmtPlugin implements Plugin<Project> {
     variants.all { variant ->
       // TODO: Consolidate common code.
 
-      // Matches:
-      // Windows: \analytics\build\BuildConfig.java
-      // Unix: /analytics/build/BuildConfig.java
-      def pattern = Pattern.compile("(.*\\/build\\/.*\\/*.java)|(.*\\build\\.*\\*.java)");
-
       def fmt = project.tasks.create "fmt${variant.name.capitalize()}", JavaFmtTask
       fmt.dependsOn variant.javaCompile
       fmt.source variant.javaCompile.source
-      fmt.exclude { !pattern.matcher(it.path).matches() }
       project.tasks.getByName("assemble").dependsOn fmt
       fmtTasks.add fmt
 
       def checkFmt = project.tasks.create "checkFmt${variant.name.capitalize()}", CheckFmtTask
       checkFmt.dependsOn variant.javaCompile
       checkFmt.source variant.javaCompile.source
-      checkFmt.exclude { !pattern.matcher(it.path).matches() }
       project.tasks.getByName("check").dependsOn checkFmt
       checkFmtTasks.add checkFmt
     }

--- a/src/main/groovy/com/f2prateek/javafmt/JavaFmtTask.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/JavaFmtTask.groovy
@@ -16,14 +16,16 @@ class JavaFmtTask extends SourceTask {
     def executor = Executors.newFixedThreadPool(2,
             new ThreadFactoryBuilder().setNameFormat("javafmt-pool-%d").build())
 
-    def tasks = getSource().collect { file ->
-      return {
-        def source = Files.asCharSource(file, Charsets.UTF_8).read()
-        def formatted = formatter.formatSource(source)
-        Files.write(formatted, file, Charsets.UTF_8)
-        return file
-      }
-    }
+    def tasks = getSource()
+            .findAll({ AndroidJavafmtPlugin.isNotBuildFile(it.path) })
+            .collect { file ->
+              return {
+                def source = Files.asCharSource(file, Charsets.UTF_8).read()
+                def formatted = formatter.formatSource(source)
+                Files.write(formatted, file, Charsets.UTF_8)
+                return file
+              }
+            }
 
     def results = executor.invokeAll(tasks)
     results.each { result ->


### PR DESCRIPTION
 12 introduce a regression that caused build and regular files to be ignored.

This fixes that regression. The ideal solution would be to use the
`excludes` directive, but this is OK for now.