### PR TITLE
Respect project.buildDir when filtering files.

### DIFF
--- a/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
@@ -12,15 +12,15 @@ class AndroidJavafmtPlugin implements Plugin<Project> {
 
   static String CONFIG_NAME = "javafmt"
   static String GOOGLE_JAVA_FORMAT = "com.google.googlejavaformat:google-java-format:1.3"
+  static Map<Project, Pattern> regexCache = [:]
 
-  // TODO: do via excludes.
-  // Matches:
-  // Windows: \analytics\build\BuildConfig.java
-  // Unix: /analytics/build/BuildConfig.java
-  static BUILD_FILE_PATTERN = Pattern.compile("(.*\\/build\\/.*\\/*.java)|(.*\\build\\.*\\*.java)")
-
-  static boolean isNotBuildFile(String path) {
-    return !BUILD_FILE_PATTERN.matcher(path).matches()
+  static boolean isNotBuildFile(Project project, String path) {
+    // TODO: do via excludes.
+    def pattern = regexCache[project]
+    if (!pattern) {
+      pattern = regexCache[project] = ~$/${project.buildDir}[\\/].*\.java/$
+    }
+    !(path ==~ pattern)
   }
 
   @Override void apply(Project project) {

--- a/src/main/groovy/com/f2prateek/javafmt/CheckFmtTask.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/CheckFmtTask.groovy
@@ -20,7 +20,7 @@ class CheckFmtTask extends SourceTask implements VerificationTask {
             new ThreadFactoryBuilder().setNameFormat("verify-javafmt-pool-%d").build())
 
     def tasks = getSource()
-            .findAll({ AndroidJavafmtPlugin.isNotBuildFile(it.path) })
+            .findAll({ AndroidJavafmtPlugin.isNotBuildFile(project, it.path) })
             .collect { file ->
               return {
                 def source = Files.asCharSource(file, Charsets.UTF_8).read()

--- a/src/main/groovy/com/f2prateek/javafmt/JavaFmtTask.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/JavaFmtTask.groovy
@@ -15,7 +15,7 @@ class JavaFmtTask extends SourceTask {
             new ThreadFactoryBuilder().setNameFormat("javafmt-pool-%d").build())
 
     def tasks = getSource()
-            .findAll({ AndroidJavafmtPlugin.isNotBuildFile(it.path) })
+            .findAll({ AndroidJavafmtPlugin.isNotBuildFile(project, it.path) })
             .collect { file ->
               return {
                 def source = Files.asCharSource(file, Charsets.UTF_8).read()


### PR DESCRIPTION
This commit requires a different regex for each project,
so the previous static pattern was replaced with a static
map of patterns. I'm not sure this optimization actually
buys anything, as I did not aggressively test for timing.