### PR TITLE
Remove `fmt` task dependency on `assemble`.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Mar 19 15:32:37 CET 2017
+#Sun Nov 19 21:26:06 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip

--- a/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
+++ b/src/main/groovy/com/f2prateek/javafmt/AndroidJavafmtPlugin.groovy
@@ -41,28 +41,26 @@ class AndroidJavafmtPlugin implements Plugin<Project> {
               "Must be applied with 'android' or 'android-library' plugin.")
     }
 
+    // Setup `fmt` tasks.
     def fmtTasks = []
-    def checkFmtTasks = []
-
     variants.all { variant ->
-      // TODO: Consolidate common code.
-
       def fmt = project.tasks.create "fmt${variant.name.capitalize()}", JavaFmtTask
       fmt.dependsOn variant.javaCompile
       fmt.source variant.javaCompile.source
-      project.tasks.getByName("assemble").dependsOn fmt
       fmtTasks.add fmt
+    }
+    def fmt = project.tasks.create "fmt"
+    fmt.dependsOn fmtTasks
 
+    // Setup `checkFmt` tasks.
+    def checkFmtTasks = []
+    variants.all { variant ->
       def checkFmt = project.tasks.create "checkFmt${variant.name.capitalize()}", CheckFmtTask
       checkFmt.dependsOn variant.javaCompile
       checkFmt.source variant.javaCompile.source
       project.tasks.getByName("check").dependsOn checkFmt
       checkFmtTasks.add checkFmt
     }
-
-    def fmt = project.tasks.create "fmt"
-    fmt.dependsOn fmtTasks
-
     def checkFmt = project.tasks.create "checkFmt"
     checkFmt.dependsOn checkFmtTasks
   }


### PR DESCRIPTION
Closes #19.

Going forwards, you'll have to run `fmt` explicitly. This is more in line with other tools like standard.